### PR TITLE
fix: Finish webview only if URL is incorrect

### DIFF
--- a/Library/src/main/java/com/infomaniak/lib/login/LoginWebViewClient.kt
+++ b/Library/src/main/java/com/infomaniak/lib/login/LoginWebViewClient.kt
@@ -87,7 +87,7 @@ open class LoginWebViewClient(
     }
 
     override fun onReceivedHttpError(view: WebView?, request: WebResourceRequest?, errorResponse: WebResourceResponse?) {
-        if (isValidUrl(request?.url.toString())) errorResult(HTTP_ERROR_CODE)
+        if (!isValidUrl(request?.url.toString())) errorResult(HTTP_ERROR_CODE)
     }
 
     private fun isValidUrl(inputUrl: String?): Boolean {


### PR DESCRIPTION
The WebView was finished when the password was incorrect instead of showing a message to inform the user.